### PR TITLE
Hide PH_P004

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Most of the reported issues have a default severity of *warning* or *suggestion*
 
 The following issues are *Hidden* by default:
 
+- [PH_P004](doc/analyzers/PH_P004.md) - CancellationToken not Passed Through (this analysis is covered by [PH_P007](doc/analyzers/PH_P007.md))
 - [PH_P005](doc/analyzers/PH_P005.md) - Missing Gate-Keeper
 - [PH_S004](doc/analyzers/PH_S004.md) - Fire-and-forget Threads
 - [PH_S006](doc/analyzers/PH_S006.md) - Unnecessarily Async Methods

--- a/src/ParallelHelper.Plugin/ReleaseNotes.txt
+++ b/src/ParallelHelper.Plugin/ReleaseNotes.txt
@@ -5,7 +5,8 @@
 - New Analyzer: PH_P009 - Synchronous Dispose in Async Method
 - New Analyzer: PH_B012 - Multiple Awaits on the Same ValueTask
 - Improved Analyzer: PH_B011 - Added support for using declarations
-- Improved: Now respecting local functions as guards for activation frames
+- Now respecting local functions as guards for activation frames
+- Set the default severity of PH_P004 to hidden since PH_P007 covers the issue
 
 
 ------------------

--- a/src/ParallelHelper/Analyzer/BestPractices/PassCancellationTokenWherePossibleAnalyzer.cs
+++ b/src/ParallelHelper/Analyzer/BestPractices/PassCancellationTokenWherePossibleAnalyzer.cs
@@ -31,7 +31,6 @@ namespace ParallelHelper.Analyzer.BestPractices {
   /// </summary>
   [DiagnosticAnalyzer(LanguageNames.CSharp)]
   public class PassCancellationTokenWherePossibleAnalyzer : DiagnosticAnalyzer {
-    // TODO Probably obsolete due to the analyzer UnusedCancellationTokenFromEnclosingScopeAnalyzer.
     public const string DiagnosticId = "PH_P004";
 
     private const string Category = "Concurrency";
@@ -41,7 +40,7 @@ namespace ParallelHelper.Analyzer.BestPractices {
     private static readonly LocalizableString Description = "";
 
     private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-      DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning,
+      DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Hidden,
       isEnabledByDefault: true, description: Description, helpLinkUri: HelpLinkFactory.CreateUri(DiagnosticId)
     );
 


### PR DESCRIPTION
The analyzer PH_P007 already covers the same information indirectly. Therefore, set the default severity to *hidden* to avoid duplicate reports when using the default settings.