### PR TITLE
Fix codecov

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,8 @@ test_script:
 after_test:
   - ps: |
       if(-not (Test-Path env:APPVEYOR_PULL_REQUEST_TITLE)) {
-        $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
-        Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
-        bash codecov.sh -f "coverage.xml" -t
+        dotnet tool install --global Codecov.Tool
+        codecov -f "coverage.xml"
       }
 
 for:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ after_test:
       if(-not (Test-Path env:APPVEYOR_PULL_REQUEST_TITLE)) {
         $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
         Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
-        bash codecov.sh -f "coverage.xml"
+        bash codecov.sh -f "coverage.xml" -t
       }
 
 for:


### PR DESCRIPTION
Recent builds showed an issue that the codecov bash script can no longer detect AppVeyor as CI; thus, no code coverage reports were uploaded any longer.
This PR fixes the mentioned issue by switching over to the nuget packaged executable.