### PR TITLE
Taskfactory startnew support task return

### DIFF
--- a/src/ParallelHelper.Plugin/ReleaseNotes.txt
+++ b/src/ParallelHelper.Plugin/ReleaseNotes.txt
@@ -3,6 +3,7 @@
 - New Analyzer: PH_P010 - Async Instead of Continuation
 - New Analyzer: PH_S027 - Leaked Outbound Collection
 - Adapted Analyzer: PH_B008 - Now only reports unsafe LINQ operations for ConcurrentDictionary
+- Improved Analyzer: PH_S014 - Now reports all task returning delegates
 
 
 ------------------

--- a/src/ParallelHelper.Test/Analyzer/Smells/TaskFactoryStartNewWithAsyncDelegateAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/Smells/TaskFactoryStartNewWithAsyncDelegateAnalyzerTest.cs
@@ -46,6 +46,57 @@ class Test {
     }
 
     [TestMethod]
+    public void ReportsStartNewWithTaskReturningMethod() {
+      const string source = @"
+using System.Threading.Tasks;
+
+class Test {
+  public Task DoWorkAsync() {
+    return Task.Factory.StartNew(DoItAsync);
+  }
+
+  public Task DoItAsync() {
+    return Task.CompletedTask;
+  }
+}";
+      VerifyDiagnostic(source, new DiagnosticResultLocation(5, 12));
+    }
+
+    [TestMethod]
+    public void ReportsStartNewWithTaskReturningLambda() {
+      const string source = @"
+using System.Threading.Tasks;
+
+class Test {
+  public Task DoWorkAsync() {
+    return Task.Factory.StartNew(() => Task.FromResult(1));
+  }
+
+  public Task DoItAsync() {
+    return Task.CompletedTask;
+  }
+}";
+      VerifyDiagnostic(source, new DiagnosticResultLocation(5, 12));
+    }
+
+    [TestMethod]
+    public void ReportsStartNewWithTaskReturningLambdaFromWrapping() {
+      const string source = @"
+using System.Threading.Tasks;
+
+class Test {
+  public Task DoWorkAsync() {
+    return Task.Factory.StartNew(() => DoItAsync());
+  }
+
+  public Task DoItAsync() {
+    return Task.CompletedTask;
+  }
+}";
+      VerifyDiagnostic(source, new DiagnosticResultLocation(5, 12));
+    }
+
+    [TestMethod]
     public void DoesNotReportStartNewWithNonAsyncMethodReference() {
       const string source = @"
 using System.Threading.Tasks;

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -19,7 +19,8 @@
     <Description>ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
     <PackageReleaseNotes>- New Analyzer: PH_P010 - Async Instead of Continuation
 - New Analyzer: PH_S027 - Leaked Outbound Collection
-- Adapted Analyzer: PH_B008 - Now only reports unsafe LINQ operations for ConcurrentDictionary</PackageReleaseNotes>
+- Adapted Analyzer: PH_B008 - Now only reports unsafe LINQ operations for ConcurrentDictionary
+- Improved Analyzer: PH_S014 - Now reports all task returning delegates</PackageReleaseNotes>
     <Copyright>Copyright (C) 2019 - 2020 Christoph Amrein, Concurrency Lab, HSR Hochschule fuer Technik Rapperswil, Switzerland</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
Introduce support for method delegates that simply return a `Task` but are not marked with the `async` keyword.