### PR TITLE
PH_S026:  Respect ConfigureAwait

### DIFF
--- a/src/ParallelHelper.Test/Analyzer/Smells/BlockingWaitInAsyncMethodAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/Smells/BlockingWaitInAsyncMethodAnalyzerTest.cs
@@ -295,5 +295,39 @@ class Test {
 }";
       VerifyDiagnostic(source);
     }
+
+    [TestMethod]
+    public void DoesNotReportsTaskWaitInAsyncMethodWhenTaskIsAwaitedWithConfigureAwait() {
+      const string source = @"
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync() {
+    var task = Task.Run(() => { });
+    await task.ConfigureAwait(false);
+    task.Wait();
+  }
+}";
+      VerifyDiagnostic(source);
+    }
+
+    [TestMethod]
+    public void DoesNotReportsTaskWaitInAsyncMethodWhenAllTasksAreAwaitedWithWhenAllAndConfigureAwait() {
+      const string source = @"
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync() {
+    var a = Task.Run(() => {});
+    var b = Task.Run(() => {});
+    var c = Task.Run(() => {});
+    await Task.WhenAll(a, b, c).ConfigureAwait(false);
+    a.Wait();
+    b.Wait();
+    c.Wait();
+  }
+}";
+      VerifyDiagnostic(source);
+    }
   }
 }


### PR DESCRIPTION
Refined the analyzer to respect the use of ConfigureAwait when filtering for previously awaited tasks.