### PR TITLE
Make PH_P012 configurable

### DIFF
--- a/doc/analyzers/PH_P012.md
+++ b/doc/analyzers/PH_P012.md
@@ -12,3 +12,10 @@ Replace the synchronization object with a suitable *Slim* counterpart, for examp
 - `System.Threading.Mutex` => `System.Threading.SemaphoreSlim`
 - `System.Threading.ReaderWriterLock` => `System.Threading.ReaderWriterLockSlim`
 - `System.Threading.ManualResetEvent` => `System.Threading.ManualResetEventSlim`
+
+## Options
+
+```
+# Named synchronization primitives: ignore (default) / report
+dotnet_diagnostic.PH_P012.named = ignore
+```

--- a/src/ParallelHelper.Test/Analyzer/AnalyzerTestBase.cs
+++ b/src/ParallelHelper.Test/Analyzer/AnalyzerTestBase.cs
@@ -1,12 +1,10 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace ParallelHelper.Test.Analyzer {
@@ -74,7 +72,7 @@ namespace ParallelHelper.Test.Analyzer {
     /// <param name="sources">The sources to analyze.</param>
     /// <param name="expectedDiagnostics">The expected diagnostics.</param>
     public void VerifyDiagnostic(IReadOnlyCollection<string> sources, params DiagnosticResultLocation[] expectedDiagnostics) {
-      VerifyDiagnostic(sources, ImmutableDictionary.Create<string, string>(), expectedDiagnostics);
+      VerifyDiagnostic(sources, ImmutableDictionary<string, string>.Empty, expectedDiagnostics);
     }
 
     /// <summary>

--- a/src/ParallelHelper.Test/Analyzer/BestPractices/PreferSlimSynchronizationAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/BestPractices/PreferSlimSynchronizationAnalyzerTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ParallelHelper.Analyzer.BestPractices;
+using System.Collections.Immutable;
 
 namespace ParallelHelper.Test.Analyzer.BestPractices {
   [TestClass]
@@ -16,7 +17,33 @@ class Test {
     }
 
     [TestMethod]
-    public void DoesNotReportCreationOfNamedSemaphore() {
+    public void ReportsCreationOfNamedSemaphoreIfEnabled() {
+      const string source = @"
+using System.Threading;
+
+class Test {
+  private readonly Semaphore _semaphore = new Semaphore(1, 1, ""access"");
+}";
+      var options = ImmutableDictionary.Create<string, string>()
+        .Add("dotnet_diagnostic.PH_P012.named", "report");
+      VerifyDiagnostic(source, options, new DiagnosticResultLocation(4, 43));
+    }
+
+    [TestMethod]
+    public void DoesNotReportCreationOfNamedSemaphoreByDefault() {
+      const string source = @"
+using System.Threading;
+
+class Test {
+  private readonly Semaphore _semaphore = new Semaphore(1, 1, ""access"");
+}";
+      var options = ImmutableDictionary.Create<string, string>()
+        .Add("dotnet_diagnostic.PH_P012.named", "ignore");
+      VerifyDiagnostic(source, options);
+    }
+
+    [TestMethod]
+    public void DoesNotReportCreationOfNamedSemaphoreIfDisabled() {
       const string source = @"
 using System.Threading;
 

--- a/src/ParallelHelper.Test/Analyzer/TestAnalyzerConfigOptionsProvider.cs
+++ b/src/ParallelHelper.Test/Analyzer/TestAnalyzerConfigOptionsProvider.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+namespace ParallelHelper.Test.Analyzer {
+  /// <summary>
+  /// Implementation of <see cref="AnalyzerConfigOptionsProvider"/> to provide analyzer settings
+  /// during test executions.
+  /// </summary>
+  internal class TestAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider {
+    private readonly AnalyzerConfigOptions _options;
+
+    public TestAnalyzerConfigOptionsProvider(ImmutableDictionary<string, string> options) {
+      _options = new TestAnalyzerConfigOptions(options);
+    }
+
+    public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) {
+      return _options;
+    }
+
+    public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) {
+      throw new System.NotImplementedException();
+    }
+
+    private class TestAnalyzerConfigOptions : AnalyzerConfigOptions {
+      private readonly ImmutableDictionary<string, string> _options;
+
+      public TestAnalyzerConfigOptions(ImmutableDictionary<string, string> options) {
+        _options = options.WithComparers(KeyComparer);
+      }
+
+      public override bool TryGetValue(string key, out string value) {
+        return _options.TryGetValue(key, out value);
+      }
+    }
+  }
+}

--- a/src/ParallelHelper/Analyzer/BestPractices/PreferSlimSynchronizationAnalyzer.cs
+++ b/src/ParallelHelper/Analyzer/BestPractices/PreferSlimSynchronizationAnalyzer.cs
@@ -63,13 +63,15 @@ namespace ParallelHelper.Analyzer.BestPractices {
     private class Analyzer : InternalAnalyzerBase<ObjectCreationExpressionSyntax> {
       public Analyzer(SyntaxNodeAnalysisContext context) : base(new SyntaxNodeAnalysisContextWrapper(context)) { }
 
+      private bool IsReportNamedEnabled => Context.Options.GetConfig(Rule, "named", "ignore") == "report";
+
       public override void Analyze() {
         var method = (IMethodSymbol)SemanticModel.GetSymbolInfo(Root, CancellationToken).Symbol;
         if(method == null) {
           return;
         }
         var primitive = GetUsedSynchronizationPrimitive(method);
-        if(primitive != null && !IsConstructingNamedPrimitive(method)) {
+        if(primitive != null && (IsReportNamedEnabled || !IsConstructingNamedPrimitive(method))) {
           Context.ReportDiagnostic(Diagnostic.Create(Rule, Root.GetLocation(), primitive.FatType, primitive.SlimType));
         }
       }

--- a/src/ParallelHelper/Analyzer/IAnalysisContext.cs
+++ b/src/ParallelHelper/Analyzer/IAnalysisContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using System.Threading;
 
 namespace ParallelHelper.Analyzer {
@@ -21,6 +22,11 @@ namespace ParallelHelper.Analyzer {
     /// Gets the root node of the currently applied analysis.
     /// </summary>
     SyntaxNode Root { get; }
+
+    /// <summary>
+    /// Gets the analyzer configuration of the analyzed syntax tree.
+    /// </summary>
+    AnalyzerConfigOptions Options { get; }
 
     /// <summary>
     /// Reports the provided diagnostic.

--- a/src/ParallelHelper/Analyzer/SemanticModelAnalysisContextWrapper.cs
+++ b/src/ParallelHelper/Analyzer/SemanticModelAnalysisContextWrapper.cs
@@ -15,6 +15,8 @@ namespace ParallelHelper.Analyzer {
 
     public SyntaxNode Root => SemanticModel.SyntaxTree.GetRoot(CancellationToken);
 
+    public AnalyzerConfigOptions Options => _instance.Options.AnalyzerConfigOptionsProvider.GetOptions(SemanticModel.SyntaxTree);
+
     /// <summary>
     /// Initializes a new instance with the specified semantic model analysis context.
     /// </summary>

--- a/src/ParallelHelper/Analyzer/SyntaxNodeAnalysisContextWrapper.cs
+++ b/src/ParallelHelper/Analyzer/SyntaxNodeAnalysisContextWrapper.cs
@@ -15,6 +15,8 @@ namespace ParallelHelper.Analyzer {
 
     public SyntaxNode Root => _instance.Node;
 
+    public AnalyzerConfigOptions Options => _instance.Options.AnalyzerConfigOptionsProvider.GetOptions(Root.SyntaxTree);
+
     /// <summary>
     /// Initializes a new instance with the specified syntax node analysis context.
     /// </summary>

--- a/src/ParallelHelper/Extensions/AnalyzerConfigOptionsExtensions.cs
+++ b/src/ParallelHelper/Extensions/AnalyzerConfigOptionsExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace ParallelHelper.Extensions {
+  /// <summary>
+  /// Extension methods to query the analyzer configurations.
+  /// </summary>
+  public static class AnalyzerConfigOptionsExtensions {
+    private const string ConfigKeyFormat = "dotnet_diagnostic.{0}.{1}";
+
+    /// <summary>
+    /// Returns the configured value or the default value if there is no configuration available.
+    /// </summary>
+    /// <param name="options">The analyzer options to query.</param>
+    /// <param name="rule">The rule asking for a specific configuration.</param>
+    /// <param name="key">The key of the specific configuration.</param>
+    /// <param name="defaultValue">The value to return if no configuration was found.</param>
+    /// <returns>The configured value or the provided default.</returns>
+    public static string GetConfig(this AnalyzerConfigOptions options, DiagnosticDescriptor rule, string key, string defaultValue) {
+      if(options.TryGetValue(GetConfigKey(rule, key), out var value)) {
+        return value;
+      }
+      return defaultValue;
+    }
+
+    private static string GetConfigKey(DiagnosticDescriptor rule, string key) {
+      return string.Format(ConfigKeyFormat, rule.Id, key);
+    }
+  }
+}


### PR DESCRIPTION
Add the option to also report named synchronization primitives.

```ini
# Named synchronization primitives: ignore (default) / report
dotnet_diagnostic.PH_P012.named = ignore
```