### PR TITLE
Simplify integration tests

### DIFF
--- a/src/ParallelHelper.Test/Analyzer/AnalyzerTestBase.cs
+++ b/src/ParallelHelper.Test/Analyzer/AnalyzerTestBase.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.Diagnostics;
-using System.Collections.Immutable;
 
 namespace ParallelHelper.Test.Analyzer {
   /// <summary>
@@ -24,23 +23,6 @@ namespace ParallelHelper.Test.Analyzer {
     public void VerifyDiagnostic(string source, params DiagnosticResultLocation[] expectedDiagnostics) {
       CreateAnalyzerCompilationBuilder()
         .AddSourceTexts(source)
-        .VerifyDiagnostic(expectedDiagnostics);
-    }
-
-    /// <summary>
-    /// Verifies that the given diagnostics are reported when analyzing the given source.
-    /// </summary>
-    /// <param name="source">The source to analyze.</param>
-    /// <param name="analyzerOptions">The analyzer options (.editorconfig settings) to pass to the analyzer.</param>
-    /// <param name="expectedDiagnostics">The expected diagnostics.</param>
-    public void VerifyDiagnostic(
-      string source,
-      ImmutableDictionary<string, string> analyzerOptions,
-      params DiagnosticResultLocation[] expectedDiagnostics
-    ) {
-      CreateAnalyzerCompilationBuilder()
-        .AddSourceTexts(source)
-        .WithAnalyzerOptions(analyzerOptions)
         .VerifyDiagnostic(expectedDiagnostics);
     }
   }

--- a/src/ParallelHelper.Test/Analyzer/BestPractices/PreferSlimSynchronizationAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/BestPractices/PreferSlimSynchronizationAnalyzerTest.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ParallelHelper.Analyzer.BestPractices;
-using System.Collections.Immutable;
 
 namespace ParallelHelper.Test.Analyzer.BestPractices {
   [TestClass]
@@ -24,9 +23,10 @@ using System.Threading;
 class Test {
   private readonly Semaphore _semaphore = new Semaphore(1, 1, ""access"");
 }";
-      var options = ImmutableDictionary.Create<string, string>()
-        .Add("dotnet_diagnostic.PH_P012.named", "report");
-      VerifyDiagnostic(source, options, new DiagnosticResultLocation(4, 43));
+      CreateAnalyzerCompilationBuilder()
+        .AddSourceTexts(source)
+        .AddAnalyzerOption("dotnet_diagnostic.PH_P012.named", "report")
+        .VerifyDiagnostic(new DiagnosticResultLocation(4, 43));
     }
 
     [TestMethod]
@@ -37,9 +37,10 @@ using System.Threading;
 class Test {
   private readonly Semaphore _semaphore = new Semaphore(1, 1, ""access"");
 }";
-      var options = ImmutableDictionary.Create<string, string>()
-        .Add("dotnet_diagnostic.PH_P012.named", "ignore");
-      VerifyDiagnostic(source, options);
+      CreateAnalyzerCompilationBuilder()
+        .AddSourceTexts(source)
+        .AddAnalyzerOption("dotnet_diagnostic.PH_P012.named", "ignore")
+        .VerifyDiagnostic();
     }
 
     [TestMethod]

--- a/src/ParallelHelper.Test/Analyzer/Bugs/MissingMonitorLockOnSingleFieldAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/Bugs/MissingMonitorLockOnSingleFieldAnalyzerTest.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ParallelHelper.Analyzer.Bugs;
-using System.Collections.Immutable;
 
 namespace ParallelHelper.Test.Analyzer.Bugs {
   [TestClass]
@@ -167,9 +166,10 @@ class Test {
     }
   }
 }";
-      var options = ImmutableDictionary.Create<string, string>()
-        .Add("dotnet_diagnostic.PH_B010.volatile", "report");
-      VerifyDiagnostic(source, options, new DiagnosticResultLocation(7, 10), new DiagnosticResultLocation(14, 14));
+      CreateAnalyzerCompilationBuilder()
+        .AddSourceTexts(source)
+        .AddAnalyzerOption("dotnet_diagnostic.PH_B010.volatile", "report")
+        .VerifyDiagnostic(new DiagnosticResultLocation(7, 10), new DiagnosticResultLocation(14, 14));
     }
 
     [TestMethod]
@@ -378,9 +378,10 @@ class Test {
     }
   }
 }";
-      var options = ImmutableDictionary.Create<string, string>()
-        .Add("dotnet_diagnostic.PH_B010.volatile", "ignore");
-      VerifyDiagnostic(source, options);
+      CreateAnalyzerCompilationBuilder()
+        .AddSourceTexts(source)
+        .AddAnalyzerOption("dotnet_diagnostic.PH_B010.volatile", "ignore")
+        .VerifyDiagnostic();
     }
   }
 }

--- a/src/ParallelHelper.Test/Analyzer/Smells/MonitorDiscouragedTypeSyncObjectAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/Smells/MonitorDiscouragedTypeSyncObjectAnalyzerTest.cs
@@ -1,9 +1,5 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ParallelHelper.Analyzer.Smells;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ParallelHelper.Test.Analyzer.Smells {
   [TestClass]
@@ -149,7 +145,7 @@ class Test {
     }
 
     [TestMethod]
-    public async Task DoesNotCrashWhenUsingVariableOfExternallyDeclaredVariableAsSyncObject() {
+    public void DoesNotCrashWhenUsingVariableOfExternallyDeclaredVariableAsSyncObject() {
       const string referenced = @"
 public class Foreign {
   public static readonly object syncObject = new object();
@@ -161,11 +157,9 @@ class Test {
     }
   }
 }";
-      var compilation = CompilationFactory.CreateCompilation(referenced, source);
-      var diagnostics = await compilation
-        .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new MonitorDiscouragedTypeSyncObjectAnalyzer()))
-        .GetAllDiagnosticsAsync();
-      Assert.AreEqual(0, diagnostics.Length);
+      CreateAnalyzerCompilationBuilder()
+        .AddSourceTexts(referenced, source)
+        .VerifyDiagnostic();
     }
   }
 }

--- a/src/ParallelHelper.Test/Analyzer/TestCompilationBuilderExtensions.cs
+++ b/src/ParallelHelper.Test/Analyzer/TestCompilationBuilderExtensions.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ParallelHelper.Test.Analyzer {
+  /// <summary>
+  /// Extension methods for the test compilation builder.
+  /// </summary>
+  internal static class TestCompilationBuilderExtensions {
+    /// <summary>
+    /// Verifies the diagnostics against the given compilation builder instance.
+    /// </summary>
+    /// <param name="compilationBuilder">The compilation builder instance to verify the diagnostics against.</param>
+    /// <param name="expectedDiagnostics">The expected diagnostics that should be yielded.</param>
+    public static void VerifyDiagnostic(this TestCompilationBuilder compilationBuilder, params DiagnosticResultLocation[] expectedDiagnostics) {
+      var diagnosticResults = Analyze(compilationBuilder);
+      Assert.AreEqual(expectedDiagnostics.Length, diagnosticResults.Length, "Invalid diagnostics count");
+      for(var i = 0; i < expectedDiagnostics.Length; ++i) {
+        var result = diagnosticResults[i];
+        var expected = expectedDiagnostics[i];
+        var span = result.Location.GetLineSpan();
+        var actual = new DiagnosticResultLocation(span.Path, span.StartLinePosition.Line, span.StartLinePosition.Character + 1);
+        Assert.AreEqual(expected, actual, "Invalid diagnostic");
+      }
+    }
+
+    private static ImmutableArray<Diagnostic> Analyze(TestCompilationBuilder compilationBuilder) {
+      var diagnostics = Task.Run(async () => await GetDiagnosticsAsync(compilationBuilder)).Result;
+      foreach(var compilationDiagnostic in diagnostics.Compilation) {
+        Console.WriteLine(compilationDiagnostic);
+      }
+      return diagnostics.Analyzer;
+    }
+
+    private static async Task<(ImmutableArray<Diagnostic> Analyzer, ImmutableArray<Diagnostic> Compilation)> GetDiagnosticsAsync(
+      TestCompilationBuilder compilationBuilder
+    ) {
+      var analyzerDiagnostics = await compilationBuilder.BuildWithAnalyzers().GetAnalyzerDiagnosticsAsync();
+      var compilationDiagnostics = compilationBuilder.Build().GetDiagnostics();
+      return (
+        // The result is ordered for better reproducability.
+        analyzerDiagnostics.OrderBy(diagnostic => diagnostic.Location.SourceSpan).ToImmutableArray(),
+        compilationDiagnostics
+          .Where(diagnostic => diagnostic.Severity >= DiagnosticSeverity.Error)
+          .OrderBy(diagnostic => diagnostic.Location.SourceSpan)
+          .ToImmutableArray()
+      );
+    }
+  }
+}

--- a/src/ParallelHelper.Test/CodeTestBuilder.cs
+++ b/src/ParallelHelper.Test/CodeTestBuilder.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ParallelHelper.Test {
+  public class CodeTestBuilder {
+    private const string DefaultSourceFilenamePattern = "Test_{0}.cs";
+
+    private static readonly MetadataReference[] References = new[] {
+      MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+      MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+      MetadataReference.CreateFromFile(Assembly.Load("netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51").Location),
+      MetadataReference.CreateFromFile(Assembly.Load("System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").Location),
+
+      MetadataReference.CreateFromFile(typeof(Thread).Assembly.Location),
+      MetadataReference.CreateFromFile(typeof(Parallel).Assembly.Location),
+      MetadataReference.CreateFromFile(typeof(ParallelQuery).Assembly.Location),
+      MetadataReference.CreateFromFile(typeof(Partitioner).Assembly.Location),
+      MetadataReference.CreateFromFile(typeof(ImmutableArray).Assembly.Location),
+
+      MetadataReference.CreateFromFile(Assembly.Load("System.Collections, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").Location),
+      MetadataReference.CreateFromFile(typeof(File).Assembly.Location),
+      MetadataReference.CreateFromFile(typeof(WebClient).Assembly.Location),
+      MetadataReference.CreateFromFile(typeof(StreamReader).Assembly.Location),
+      MetadataReference.CreateFromFile(typeof(Socket).Assembly.Location),
+      MetadataReference.CreateFromFile(typeof(Uri).Assembly.Location)
+    };
+
+    private static readonly CSharpCompilation BaseCompilation = CSharpCompilation.Create(
+      assemblyName: "test.dll",
+      references: References,
+      options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+    );
+
+    public CSharpCompilation Compilation { get; private set; } = BaseCompilation;
+    public int SourceCount { get; private set; }
+    public ImmutableDictionary<string, string> AnalyzerOptions { get; private set; }
+      = ImmutableDictionary.Create<string, string>(AnalyzerConfigOptions.KeyComparer);
+
+    private CodeTestBuilder() { }
+
+    public static CodeTestBuilder Create() {
+      return new CodeTestBuilder();
+    }
+
+    private CodeTestBuilder(CodeTestBuilder other) {
+      Compilation = other.Compilation;
+      SourceCount = other.SourceCount;
+      AnalyzerOptions = other.AnalyzerOptions;
+    }
+
+    public CodeTestBuilder AddSourceTexts(params string[] sourceTexts) {
+      var syntaxTrees = sourceTexts.Select((source, index) => CSharpSyntaxTree.ParseText(
+        source, path: string.Format(DefaultSourceFilenamePattern, SourceCount + index)
+      )).ToArray();
+      return new CodeTestBuilder(this) {
+        Compilation = Compilation.AddSyntaxTrees(syntaxTrees),
+        SourceCount = SourceCount + syntaxTrees.Length
+      };
+    }
+
+    public CodeTestBuilder WithReferences(params MetadataReference[] references) {
+      return new CodeTestBuilder(this) {
+        Compilation = Compilation.WithReferences(references)
+      };
+    }
+
+    public CodeTestBuilder AddAnalyzerOption(string key, string value) {
+      return new CodeTestBuilder(this) {
+        AnalyzerOptions = AnalyzerOptions.Add(key, value)
+      };
+    }
+  }
+}

--- a/src/ParallelHelper.Test/CompilationFactory.cs
+++ b/src/ParallelHelper.Test/CompilationFactory.cs
@@ -4,12 +4,6 @@ using System.Linq;
 
 namespace ParallelHelper.Test {
   internal class CompilationFactory {
-    public static Compilation CreateCompilation(params string[] sources) {
-      return TestCompilationBuilder.Create()
-        .AddSourceTexts(sources)
-        .Build();
-    }
-
     public static IEnumerable<TSyntaxNode> GetNodesOfType<TSyntaxNode>(string source) where TSyntaxNode : SyntaxNode {
       return CreateCompilation(source)
         .SyntaxTrees
@@ -23,6 +17,12 @@ namespace ParallelHelper.Test {
       var compilation = CreateCompilation(source);
       var syntaxTree = compilation.SyntaxTrees.Single();
       return compilation.GetSemanticModel(syntaxTree);
+    }
+
+    private static Compilation CreateCompilation(params string[] sources) {
+      return TestCompilationBuilder.Create()
+        .AddSourceTexts(sources)
+        .Build();
     }
   }
 }

--- a/src/ParallelHelper.Test/CompilationFactory.cs
+++ b/src/ParallelHelper.Test/CompilationFactory.cs
@@ -5,11 +5,9 @@ using System.Linq;
 namespace ParallelHelper.Test {
   internal class CompilationFactory {
     public static Compilation CreateCompilation(params string[] sources) {
-      //var syntaxTrees = sources.Select(source => CSharpSyntaxTree.ParseText(source, default, TestSourceFilePath));
-      //return CSharpCompilation.Create("Test.dll", syntaxTrees, References, CompilationOptions);
-      return CodeTestBuilder.Create()
+      return TestCompilationBuilder.Create()
         .AddSourceTexts(sources)
-        .Compilation;
+        .Build();
     }
 
     public static IEnumerable<TSyntaxNode> GetNodesOfType<TSyntaxNode>(string source) where TSyntaxNode : SyntaxNode {

--- a/src/ParallelHelper.Test/CompilationFactory.cs
+++ b/src/ParallelHelper.Test/CompilationFactory.cs
@@ -1,44 +1,15 @@
 ﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Sockets;
-using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace ParallelHelper.Test {
   internal class CompilationFactory {
-    private static readonly MetadataReference[] References = new[] {
-      MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-      MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
-      MetadataReference.CreateFromFile(Assembly.Load("netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51").Location),
-      MetadataReference.CreateFromFile(Assembly.Load("System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").Location),
-
-      MetadataReference.CreateFromFile(typeof(Thread).Assembly.Location),
-      MetadataReference.CreateFromFile(typeof(Parallel).Assembly.Location),
-      MetadataReference.CreateFromFile(typeof(ParallelQuery).Assembly.Location),
-      MetadataReference.CreateFromFile(typeof(Partitioner).Assembly.Location),
-      MetadataReference.CreateFromFile(typeof(ImmutableArray).Assembly.Location),
-
-      MetadataReference.CreateFromFile(Assembly.Load("System.Collections, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").Location),
-      MetadataReference.CreateFromFile(typeof(File).Assembly.Location),
-      MetadataReference.CreateFromFile(typeof(WebClient).Assembly.Location),
-      MetadataReference.CreateFromFile(typeof(StreamReader).Assembly.Location),
-      MetadataReference.CreateFromFile(typeof(Socket).Assembly.Location),
-      MetadataReference.CreateFromFile(typeof(Uri).Assembly.Location)
-    };
-    private static readonly CSharpCompilationOptions CompilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
-    private const string TestSourceFilePath = "Test.cs";
-
     public static Compilation CreateCompilation(params string[] sources) {
-      var syntaxTrees = sources.Select(source => CSharpSyntaxTree.ParseText(source, default, TestSourceFilePath));
-      return CSharpCompilation.Create("Test.dll", syntaxTrees, References, CompilationOptions);
+      //var syntaxTrees = sources.Select(source => CSharpSyntaxTree.ParseText(source, default, TestSourceFilePath));
+      //return CSharpCompilation.Create("Test.dll", syntaxTrees, References, CompilationOptions);
+      return CodeTestBuilder.Create()
+        .AddSourceTexts(sources)
+        .Compilation;
     }
 
     public static IEnumerable<TSyntaxNode> GetNodesOfType<TSyntaxNode>(string source) where TSyntaxNode : SyntaxNode {

--- a/src/ParallelHelper.Test/DiagnosticResultLocation.cs
+++ b/src/ParallelHelper.Test/DiagnosticResultLocation.cs
@@ -11,7 +11,7 @@ namespace ParallelHelper.Test {
 
     private readonly int _hashCode;
 
-    public DiagnosticResultLocation(int line, int column) : this("Test.cs", line, column) { }
+    public DiagnosticResultLocation(int line, int column) : this("Test_0.cs", line, column) { }
 
     public DiagnosticResultLocation(string path, int line, int column) {
       Path = path;

--- a/src/ParallelHelper.Test/Extensions/SemanticModelExtensionsTest.cs
+++ b/src/ParallelHelper.Test/Extensions/SemanticModelExtensionsTest.cs
@@ -588,7 +588,9 @@ public class Test {
     return Foreign.DoIt;
   }
 }";
-      var compilation = CompilationFactory.CreateCompilation(referenced, source);
+      var compilation = TestCompilationBuilder.Create()
+        .AddSourceTexts(referenced, source)
+        .Build();
       var syntaxTree = compilation.SyntaxTrees
         .Where(tree => tree.GetRoot().DescendantNodesAndSelf().OfType<ClassDeclarationSyntax>().Single().Identifier.Text == "Test")
         .Single();

--- a/src/ParallelHelper.Test/TestAnalyzerConfigOptionsProvider.cs
+++ b/src/ParallelHelper.Test/TestAnalyzerConfigOptionsProvider.cs
@@ -2,7 +2,7 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
 
-namespace ParallelHelper.Test.Analyzer {
+namespace ParallelHelper.Test {
   /// <summary>
   /// Implementation of <see cref="AnalyzerConfigOptionsProvider"/> to provide analyzer settings
   /// during test executions.

--- a/src/ParallelHelper.Test/TestCompilationBuilder.cs
+++ b/src/ParallelHelper.Test/TestCompilationBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
-using ParallelHelper.Test.Analyzer;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
@@ -14,6 +13,10 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace ParallelHelper.Test {
+  /// <summary>
+  /// Class to setup a <see cref="CSharpCompilation"/> and a <see cref="CompilationWithAnalyzers"/> instance
+  /// with common settings. All changes are immutable; thus, intermediate states can be used independently.
+  /// </summary>
   public class TestCompilationBuilder {
     private const string DefaultSourceFilenamePattern = "Test_{0}.cs";
 
@@ -43,66 +46,103 @@ namespace ParallelHelper.Test {
       options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
     );
 
-    public CSharpCompilation Compilation { get; private set; } = BaseCompilation;
-    public ImmutableDictionary<string, string> AnalyzerOptions { get; private set; }
-      = ImmutableDictionary.Create<string, string>(AnalyzerConfigOptions.KeyComparer);
-    public ImmutableArray<DiagnosticAnalyzer> Analyzers { get; private set; } = ImmutableArray<DiagnosticAnalyzer>.Empty;
+    private CSharpCompilation _compilation = BaseCompilation;
+    private ImmutableDictionary<string, string> _analyzerOptions = ImmutableDictionary.Create<string, string>(AnalyzerConfigOptions.KeyComparer);
+    private ImmutableArray<DiagnosticAnalyzer> _analyzers = ImmutableArray<DiagnosticAnalyzer>.Empty;
 
     private TestCompilationBuilder() { }
 
+    /// <summary>
+    /// Creates a new builder instance.
+    /// </summary>
+    /// <returns>The newly created builder instance.</returns>
     public static TestCompilationBuilder Create() {
       return new TestCompilationBuilder();
     }
 
     private TestCompilationBuilder(TestCompilationBuilder other) {
-      Compilation = other.Compilation;
-      AnalyzerOptions = other.AnalyzerOptions;
-      Analyzers = other.Analyzers;
+      _compilation = other._compilation;
+      _analyzerOptions = other._analyzerOptions;
+      _analyzers = other._analyzers;
     }
 
+    /// <summary>
+    /// Adds the given list of sources to the compilation with an automatically generated name.
+    /// </summary>
+    /// <param name="sourceTexts">The source texts to add.</param>
+    /// <returns>A new compilation builder instance that includes the new source texts.</returns>
     public TestCompilationBuilder AddSourceTexts(params string[] sourceTexts) {
       var syntaxTrees = sourceTexts.Select((source, index) => CSharpSyntaxTree.ParseText(
-        source, path: string.Format(DefaultSourceFilenamePattern, Compilation.SyntaxTrees.Length + index)
+        source, path: string.Format(DefaultSourceFilenamePattern, _compilation.SyntaxTrees.Length + index)
       )).ToArray();
       return new TestCompilationBuilder(this) {
-        Compilation = Compilation.AddSyntaxTrees(syntaxTrees),
+        _compilation = _compilation.AddSyntaxTrees(syntaxTrees),
       };
     }
 
+    /// <summary>
+    /// Adds the given list of references to the compilation.
+    /// </summary>
+    /// <param name="references">The references to add.</param>
+    /// <returns>A new compilation builder instance that includes the new references.</returns>
     public TestCompilationBuilder AddReferences(params MetadataReference[] references) {
       return new TestCompilationBuilder(this) {
-        Compilation = Compilation.AddReferences(references)
+        _compilation = _compilation.AddReferences(references)
       };
     }
 
+    /// <summary>
+    /// Adds the given analyzer option to the compilation.
+    /// </summary>
+    /// <param name="key">The key of the analyzer option to add.</param>
+    /// <param name="value">The value of the analyzer option to add.</param>
+    /// <returns>A new compilation builder instance that includes the new analyzer option.</returns>
     public TestCompilationBuilder AddAnalyzerOption(string key, string value) {
       return new TestCompilationBuilder(this) {
-        AnalyzerOptions = AnalyzerOptions.Add(key, value)
+        _analyzerOptions = _analyzerOptions.Add(key, value)
       };
     }
 
+    /// <summary>
+    /// Replaces the previously configured analyzer options with the provided ones.
+    /// </summary>
+    /// <param name="analyzerOptions">The new analyzer options.</param>
+    /// <returns>A new compilation builder instance that replaced all analyzer options with the given ones.</returns>
     public TestCompilationBuilder WithAnalyzerOptions(ImmutableDictionary<string, string> analyzerOptions) {
       return new TestCompilationBuilder(this) {
-        AnalyzerOptions = analyzerOptions
+        _analyzerOptions = analyzerOptions
       };
     }
 
-    public TestCompilationBuilder AddAnalyzers(params DiagnosticAnalyzer[] analyzer) {
+    /// <summary>
+    /// Adds the given list of analyzers to the compilation.
+    /// </summary>
+    /// <param name="analyzers">The key of the analyzer option to add.</param>
+    /// <returns>A new compilation builder instance that includes the new analyzers.</returns>
+    public TestCompilationBuilder AddAnalyzers(params DiagnosticAnalyzer[] analyzers) {
       return new TestCompilationBuilder(this) {
-        Analyzers = Analyzers.AddRange(analyzer)
+        _analyzers = _analyzers.AddRange(analyzers)
       };
     }
 
+    /// <summary>
+    /// Generates a compilation with the configured settings.
+    /// </summary>
+    /// <returns>The new compilation.</returns>
     public CSharpCompilation Build() {
-      return Compilation;
+      return _compilation;
     }
 
+    /// <summary>
+    /// Generates a compilation that includes analyzers with the configured settings.
+    /// </summary>
+    /// <returns>The new compilation.</returns>
     public CompilationWithAnalyzers BuildWithAnalyzers() {
-      return Compilation.WithAnalyzers(
-        Analyzers,
+      return _compilation.WithAnalyzers(
+        _analyzers,
         new AnalyzerOptions(
           ImmutableArray<AdditionalText>.Empty,
-          new TestAnalyzerConfigOptionsProvider(AnalyzerOptions)
+          new TestAnalyzerConfigOptionsProvider(_analyzerOptions)
         )
       );
     }


### PR DESCRIPTION
The new configuration possibilities require more flexibility for the integration test setup. Therefore, replace the various method overloads with an immutable daisy-chain approach.