### PR TITLE
PH_S019: Add support for method exclusions

### DIFF
--- a/doc/analyzers/PH_S009.md
+++ b/doc/analyzers/PH_S009.md
@@ -7,3 +7,7 @@ The use of Parallel LINQ with side-effects in its body is discouraged. Moreover,
 ## Solution
 
 Apply the aggregation in a LINQ operation without side-effects and use the result of the expression.
+
+## Additional Note
+
+The methods `AddAsync` and `AddRangeAsync` of entity framework's `DbSet` and `DbContext` are explicitely excluded from this analysis. The [documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontext.addasync?view=efcore-5.0) recommends using the non-async versions instead.

--- a/doc/analyzers/PH_S009.md
+++ b/doc/analyzers/PH_S009.md
@@ -7,7 +7,3 @@ The use of Parallel LINQ with side-effects in its body is discouraged. Moreover,
 ## Solution
 
 Apply the aggregation in a LINQ operation without side-effects and use the result of the expression.
-
-## Additional Note
-
-The methods `AddAsync` and `AddRangeAsync` of entity framework's `DbSet` and `DbContext` are explicitely excluded from this analysis. The [documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontext.addasync?view=efcore-5.0) recommends using the non-async versions instead.

--- a/doc/analyzers/PH_S019.md
+++ b/doc/analyzers/PH_S019.md
@@ -7,3 +7,7 @@ An asynchronous method makes use of a blocking method, although there exists an 
 ## Solution
 
 Replace the blocking method with its asynchronous counterpart.
+
+## Additional Note
+
+The methods `AddAsync` and `AddRangeAsync` of entity framework's `DbSet` and `DbContext` are explicitely excluded from this analysis by default. The [documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontext.addasync?view=efcore-5.0) recommends using the non-async versions instead.

--- a/doc/analyzers/PH_S019.md
+++ b/doc/analyzers/PH_S019.md
@@ -11,3 +11,11 @@ Replace the blocking method with its asynchronous counterpart.
 ## Additional Note
 
 The methods `AddAsync` and `AddRangeAsync` of entity framework's `DbSet` and `DbContext` are explicitely excluded from this analysis by default. The [documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontext.addasync?view=efcore-5.0) recommends using the non-async versions instead.
+
+## Options
+
+```
+# A white-space separated list of methods to exclude when searching for async counterparts
+# Format: <type-specifier>:<method1>,<method2>
+dotnet_diagnostic.PH_P012.named = Microsoft.EntityFrameworkCore.DbContext:Add,AddRange Microsoft.EntityFrameworkCore.DbSet`1:Add,AddRange
+```

--- a/doc/analyzers/PH_S019.md
+++ b/doc/analyzers/PH_S019.md
@@ -17,5 +17,5 @@ The methods `AddAsync` and `AddRangeAsync` of entity framework's `DbSet` and `Db
 ```
 # A white-space separated list of methods to exclude when searching for async counterparts
 # Format: <type-specifier>:<method1>,<method2>
-dotnet_diagnostic.PH_P012.named = Microsoft.EntityFrameworkCore.DbContext:Add,AddRange Microsoft.EntityFrameworkCore.DbSet`1:Add,AddRange
+dotnet_diagnostic.PH_P019.exclusions = Microsoft.EntityFrameworkCore.DbContext:Add,AddRange Microsoft.EntityFrameworkCore.DbSet`1:Add,AddRange
 ```

--- a/reportall.editorconfig
+++ b/reportall.editorconfig
@@ -36,6 +36,7 @@ dotnet_diagnostic.PH_S016.severity = warning
 dotnet_diagnostic.PH_S017.severity = warning
 dotnet_diagnostic.PH_S018.severity = warning
 dotnet_diagnostic.PH_S019.severity = warning
+dotnet_diagnostic.PH_S019.exclusions = 
 dotnet_diagnostic.PH_S020.severity = warning
 dotnet_diagnostic.PH_S021.severity = warning
 dotnet_diagnostic.PH_S022.severity = warning

--- a/src/ParallelHelper.Plugin/ReleaseNotes.txt
+++ b/src/ParallelHelper.Plugin/ReleaseNotes.txt
@@ -3,6 +3,7 @@
 - New Analyzer: PH_B015 - Disposed Task Instead of Value
 - Improved Analyzer: PH_S007 - Now respects activation frames
 - Improved Analyzer: PH_P007 - Now reports default expressions where a token is available
+- Improved Analyzer: PH_S019 - Now ignores EF Core's Add and AddRange of DbSet and DbContext by default
 - Improved Analyzer: PH_S025 - Now supports lambda expressions and respects activation frames
 
 

--- a/src/ParallelHelper/Analyzer/Smells/BlockingMethodWithAsyncCounterpartInAsyncMethodAnalyzer.cs
+++ b/src/ParallelHelper/Analyzer/Smells/BlockingMethodWithAsyncCounterpartInAsyncMethodAnalyzer.cs
@@ -49,7 +49,7 @@ namespace ParallelHelper.Analyzer.Smells {
 
     private static readonly MethodDescriptor[] ExcludedMethods = {
       new MethodDescriptor("Microsoft.EntityFrameworkCore.DbContext", "Add", "AddRange"),
-      new MethodDescriptor("Microsoft.EntityFrameworkCore.DbSet", "Add", "AddRange")
+      new MethodDescriptor("Microsoft.EntityFrameworkCore.DbSet`1", "Add", "AddRange")
     };
 
     public override void Initialize(AnalysisContext context) {

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -20,6 +20,7 @@
     <PackageReleaseNotes>- New Analyzer: PH_B015 - Disposed Task Instead of Value
 - Improved Analyzer: PH_S007 - Now respects activation frames
 - Improved Analyzer: PH_P007 - Now reports default expressions where a token is available
+- Improved Analyzer: PH_S019 - Now ignores EF Core's Add and AddRange of DbSet and DbContext by default
 - Improved Analyzer: PH_S025 - Now supports lambda expressions and respects activation frames</PackageReleaseNotes>
     <Copyright>Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>


### PR DESCRIPTION
Initially requested in #64 to exclude EF-Cores Add and AddRange of DbSet and DbContext from the analysis. These methods are now excluded by default and can be further configured with an editorconfig entry with the key `dotnet_diagnostic.PH_P019.exclusions`.