### PR TITLE
PH_S019: Add return type matching

### DIFF
--- a/doc/analyzers/PH_S019.md
+++ b/doc/analyzers/PH_S019.md
@@ -18,4 +18,7 @@ The methods `AddAsync` and `AddRangeAsync` of entity framework's `DbSet` and `Db
 # A white-space separated list of methods to exclude when searching for async counterparts
 # Format: <type-specifier>:<method1>,<method2>
 dotnet_diagnostic.PH_P019.exclusions = Microsoft.EntityFrameworkCore.DbContext:Add,AddRange Microsoft.EntityFrameworkCore.DbSet`1:Add,AddRange
+
+# Only report async methods that have a compatible return type: match (default) / ignore
+dotnet_diagnostic.PH_P019.returnType = match
 ```

--- a/reportall.editorconfig
+++ b/reportall.editorconfig
@@ -37,6 +37,7 @@ dotnet_diagnostic.PH_S017.severity = warning
 dotnet_diagnostic.PH_S018.severity = warning
 dotnet_diagnostic.PH_S019.severity = warning
 dotnet_diagnostic.PH_S019.exclusions = 
+dotnet_diagnostic.PH_P019.returnType = ignore
 dotnet_diagnostic.PH_S020.severity = warning
 dotnet_diagnostic.PH_S021.severity = warning
 dotnet_diagnostic.PH_S022.severity = warning

--- a/src/ParallelHelper.Plugin/ReleaseNotes.txt
+++ b/src/ParallelHelper.Plugin/ReleaseNotes.txt
@@ -1,4 +1,11 @@
-﻿v3.1.0
+﻿v3.2.0
+
+- Improved Analyzer: PH_S019 - Now matches the return-type by default
+
+
+------------------
+
+v3.1.0
 
 - New Analyzer: PH_B015 - Disposed Task Instead of Value
 - Improved Analyzer: PH_S007 - Now respects activation frames

--- a/src/ParallelHelper.Plugin/source.extension.vsixmanifest
+++ b/src/ParallelHelper.Plugin/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ParallelHelper.f833642b-cd24-49ac-addc-e5328ce8fe88" Version="3.1.0" Language="en-US" Publisher="Christoph Amrein" />
+        <Identity Id="ParallelHelper.f833642b-cd24-49ac-addc-e5328ce8fe88" Version="3.2.0" Language="en-US" Publisher="Christoph Amrein" />
         <DisplayName>ParallelHelper</DisplayName>
         <Description xml:space="preserve">ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
         <MoreInfo>https://github.com/Concurrency-Lab/ParallelHelper</MoreInfo>

--- a/src/ParallelHelper.Test/Analyzer/Smells/BlockingMethodWithAsyncCounterpartInAsyncMethodAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/Smells/BlockingMethodWithAsyncCounterpartInAsyncMethodAnalyzerTest.cs
@@ -109,6 +109,29 @@ class Test {
     }
 
     [TestMethod]
+    public void ReportsAccessToMethodReturningValueWithAsyncCounterpartReturningValueOfSameType() {
+      const string source = @"
+using System.IO;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync() {
+    var value = GetIt();
+  }
+
+  public int GetIt() {
+    return 1;
+  }
+
+  public Task<int> GetItAsync() {
+    return Task.FromResult(1);
+  }
+}";
+      VerifyDiagnostic(source, new DiagnosticResultLocation(7, 17));
+    }
+
+    [TestMethod]
     public void ReportsReadOfTypeWithReadAsyncInAsyncMethodIfExclusionEntryIsInvalid() {
       const string source = @"
 using System.IO;
@@ -368,6 +391,95 @@ System.IO.StreamReader:ReadLine,Read,ReadBlock";
         .AddSourceTexts(source)
         .AddAnalyzerOption("dotnet_diagnostic.PH_S019.exclusions", exclusions)
         .VerifyDiagnostic();
+    }
+
+    [TestMethod]
+    public void DoesNotReportAccessToMethodReturningVoidWithAsyncCounterpartReturningValue() {
+      const string source = @"
+using System.IO;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync() {
+    DoIt();
+  }
+
+  public void DoIt() {
+  }
+
+  public Task<int> DoItAsync() {
+    return Task.FromResult(1);
+  }
+}";
+      VerifyDiagnostic(source);
+    }
+
+    [TestMethod]
+    public void DoesNotReportAccessToMethodReturningValueWithAsyncCounterpartReturningValueOfDifferentType() {
+      const string source = @"
+using System.IO;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync() {
+    var value = GetIt();
+  }
+
+  public double GetIt() {
+    return 1.0;
+  }
+
+  public Task<int> GetItAsync() {
+    return Task.FromResult(1);
+  }
+}";
+      VerifyDiagnostic(source);
+    }
+
+    [TestMethod]
+    public void DoesNotReportAccessToMethodReturningValueWithAsyncCounterpartReturningNoValue() {
+      const string source = @"
+using System.IO;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync() {
+    var value = GetIt();
+  }
+
+  public int GetIt() {
+    return 1;
+  }
+
+  public Task GetItAsync() {
+    return Task.CompletedTask;
+  }
+}";
+      VerifyDiagnostic(source);
+    }
+
+    [TestMethod]
+    public void DoesNotReportAccessToMethodWithAsyncCounterpartThatIsNotAwaitable() {
+      const string source = @"
+using System.IO;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync() {
+    var value = GetIt();
+  }
+
+  public void DoIt() {
+  }
+
+  public void DoItAsync() {
+  }
+}";
+      VerifyDiagnostic(source);
     }
   }
 }

--- a/src/ParallelHelper.Test/Analyzer/Smells/BlockingMethodWithAsyncCounterpartInAsyncMethodAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/Smells/BlockingMethodWithAsyncCounterpartInAsyncMethodAnalyzerTest.cs
@@ -154,6 +154,58 @@ class Test {
     }
 
     [TestMethod]
+    public void ReportsAccessToMethodReturningValueWithAsyncCounterpartReturningValueOfDifferentTypeIfMatchReturnTypeIsDisabled() {
+      const string source = @"
+using System.IO;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync() {
+    var value = GetIt();
+  }
+
+  public double GetIt() {
+    return 1.0;
+  }
+
+  public Task<int> GetItAsync() {
+    return Task.FromResult(1);
+  }
+}";
+      CreateAnalyzerCompilationBuilder()
+        .AddSourceTexts(source)
+        .AddAnalyzerOption("dotnet_diagnostic.PH_S019.returnType", "ignore")
+        .VerifyDiagnostic(new DiagnosticResultLocation(7, 17));
+    }
+
+    [TestMethod]
+    public void ReportsAccessToMethodReturningValueWithAsyncCounterpartReturningNoValueIfMatchReturnTypeIsDisabled() {
+      const string source = @"
+using System.IO;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync() {
+    var value = GetIt();
+  }
+
+  public int GetIt() {
+    return 1;
+  }
+
+  public Task GetItAsync() {
+    return Task.CompletedTask;
+  }
+}";
+      CreateAnalyzerCompilationBuilder()
+        .AddSourceTexts(source)
+        .AddAnalyzerOption("dotnet_diagnostic.PH_S019.returnType", "ignore")
+        .VerifyDiagnostic(new DiagnosticResultLocation(7, 17));
+    }
+
+    [TestMethod]
     public void DoesNotReportReadOfTypeWithReadAsyncInNonAsyncMethod() {
       const string source = @"
 using System.IO;

--- a/src/ParallelHelper.Test/Analyzer/Smells/BlockingMethodWithAsyncCounterpartInAsyncMethodAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/Smells/BlockingMethodWithAsyncCounterpartInAsyncMethodAnalyzerTest.cs
@@ -47,6 +47,7 @@ class Test {
     [TestMethod]
     public void ReportsReadOfTypeWithReadAsyncInAsyncSimpleLambda() {
       const string source = @"
+using System;
 using System.IO;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -62,7 +63,7 @@ class Test {
     };
   }
 }";
-      VerifyDiagnostic(source, new DiagnosticResultLocation(11, 9));
+      VerifyDiagnostic(source, new DiagnosticResultLocation(12, 9));
     }
 
     [TestMethod]
@@ -522,7 +523,7 @@ using System.Threading.Tasks;
 
 class Test {
   public async Task DoWorkAsync() {
-    var value = GetIt();
+    DoIt();
   }
 
   public void DoIt() {

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -27,7 +27,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Company>Concurrency Lab, HSR Hochschule fuer Technik Rapperswil, Switzerland</Company>
+    <Company>Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Company>
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -11,17 +11,13 @@
 
   <PropertyGroup>
     <PackageId>ParallelHelper</PackageId>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <Authors>Christoph Amrein</Authors>
     <PackageProjectUrl>https://github.com/Concurrency-Lab/ParallelHelper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Concurrency-Lab/ParallelHelper</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <Description>ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
-    <PackageReleaseNotes>- New Analyzer: PH_B015 - Disposed Task Instead of Value
-- Improved Analyzer: PH_S007 - Now respects activation frames
-- Improved Analyzer: PH_P007 - Now reports default expressions where a token is available
-- Improved Analyzer: PH_S019 - Now ignores EF Core's Add and AddRange of DbSet and DbContext by default
-- Improved Analyzer: PH_S025 - Now supports lambda expressions and respects activation frames</PackageReleaseNotes>
+    <PackageReleaseNotes>- Improved Analyzer: PH_S019 - Now matches the return-type by default</PackageReleaseNotes>
     <Copyright>Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
As suggested with issue #66, add the possibility to filter async-candidates by their return type compatibility.