### PR TITLE
PH_P005: Rename to Blocking Wait on Async Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Most of the reported issues have a default severity of *warning* or *suggestion*
 The following issues are *Hidden* by default:
 
 - [PH_P004](doc/analyzers/PH_P004.md) - CancellationToken not Passed Through (this analysis is covered by [PH_P007](doc/analyzers/PH_P007.md))
-- [PH_P005](doc/analyzers/PH_P005.md) - Missing Gate-Keeper
+- [PH_P005](doc/analyzers/PH_P005.md) - Blocking Wait on Async Method
 - [PH_P010](doc/analyzers/PH_P010.md) - Async Instead of Continuation
 - [PH_S004](doc/analyzers/PH_S004.md) - Fire-and-forget Threads
 - [PH_S006](doc/analyzers/PH_S006.md) - Unnecessarily Async Methods

--- a/doc/analyzers/PH_P005.md
+++ b/doc/analyzers/PH_P005.md
@@ -1,4 +1,4 @@
-# PH_P005 - Missing Gate-Keeper
+# PH_P005 - Blocking Wait on Async Method
 
 ## Problem
 

--- a/doc/analyzers/PH_P005.md
+++ b/doc/analyzers/PH_P005.md
@@ -10,7 +10,13 @@ var data = ReadAsync().Result;
 
 ## Solution
 
-Enclose the call of the asynchronous method with `Task.Run(...)`. This setup ensures that there is no synchronization context in the call-chain that may block the continuation of the synchronization context.
+Non-blockingly wait for the task completion using `await`.
+
+```cs
+var data = await ReadAsync();
+```
+
+If it is impossible to make the caller method `async`, first and foremost, search for the synchronous counterpart of the asynchronous method. If that is not possible, use a gate-keeper to avoid capturing the synchronization context: Enclose the call of the asynchronous method with `Task.Run(...)`. This setup ensures that there is no synchronization context in the call-chain that may block the continuation of the synchronization context.
 
 ```cs
 var data = Task.Run(async () => await ReadAsync()).Result;

--- a/src/ParallelHelper.Plugin/ReleaseNotes.txt
+++ b/src/ParallelHelper.Plugin/ReleaseNotes.txt
@@ -2,6 +2,7 @@
 
 - New Analyzer: PH_P013 - Discouraged EntityFramework Method
 - Renamed Analyzer: PH_P003 - Discouraged Thread Method (was Discouraged Method)
+- Renamed Analyzer: PH_P005 - Blocking Wait on Async Method (was Missing Gate-Keeper)
 - Improved Analyzer: PH_B014 - Now reports await of as-expressions
 
 

--- a/src/ParallelHelper.Test/Analyzer/BestPractices/BlockingWaitOnAsyncMethodAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/BestPractices/BlockingWaitOnAsyncMethodAnalyzerTest.cs
@@ -3,7 +3,7 @@ using ParallelHelper.Analyzer.BestPractices;
 
 namespace ParallelHelper.Test.Analyzer.BestPractices {
   [TestClass]
-  public class MissingAsyncGateKeeperAnalyzerTest : AnalyzerTestBase<MissingAsyncGateKeeperAnalyzer> {
+  public class BlockingWaitOnAsyncMethodAnalyzerTest : AnalyzerTestBase<BlockingWaitOnAsyncMethodAnalyzer> {
     [TestMethod]
     public void ReportsWaitOnAsyncMethod() {
       const string source = @"

--- a/src/ParallelHelper/Analyzer/BestPractices/BlockingWaitOnAsyncMethodAnalyzer.cs
+++ b/src/ParallelHelper/Analyzer/BestPractices/BlockingWaitOnAsyncMethodAnalyzer.cs
@@ -30,14 +30,14 @@ namespace ParallelHelper.Analyzer.BestPractices {
   /// </example>
   /// </summary>
   [DiagnosticAnalyzer(LanguageNames.CSharp)]
-  public class MissingAsyncGateKeeperAnalyzer : DiagnosticAnalyzer {
+  public class BlockingWaitOnAsyncMethodAnalyzer : DiagnosticAnalyzer {
     // TODO maybe limit this to only analyze code that potentially has a synchronization context.
     public const string DiagnosticId = "PH_P005";
 
     private const string Category = "Concurrency";
 
-    private static readonly LocalizableString Title = "Missing Gate-Keeper";
-    private static readonly LocalizableString MessageFormat = "The blocking access '{0}' lacks a gate-keeper. It is recommended to enclose blocking task operations with a Task.Run to prevent the capturing of the synchronization context.";
+    private static readonly LocalizableString Title = "Blocking Wait on Async Method";
+    private static readonly LocalizableString MessageFormat = "The access is '{0}' is blocking. Either use the async/await pattern or use a gate-keeper to prevent capturing of the synchronization context.";
     private static readonly LocalizableString Description = "";
 
     private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
@@ -87,6 +87,7 @@ namespace ParallelHelper.Analyzer.BestPractices {
       }
 
       public override void Analyze() {
+        var list = new List<string>();
         if(SemanticModel.GetSymbolInfo(Root, CancellationToken).Symbol is TMemberSymbol member && IsBlockingMemberAccessOnAsyncMethod(member)) {
           var access = $"{member.ContainingType.Name}.{member.Name}";
           Context.ReportDiagnostic(Diagnostic.Create(Rule, Root.GetLocation(), access));

--- a/src/ParallelHelper/Analyzer/BestPractices/BlockingWaitOnAsyncMethodAnalyzer.cs
+++ b/src/ParallelHelper/Analyzer/BestPractices/BlockingWaitOnAsyncMethodAnalyzer.cs
@@ -87,7 +87,6 @@ namespace ParallelHelper.Analyzer.BestPractices {
       }
 
       public override void Analyze() {
-        var list = new List<string>();
         if(SemanticModel.GetSymbolInfo(Root, CancellationToken).Symbol is TMemberSymbol member && IsBlockingMemberAccessOnAsyncMethod(member)) {
           var access = $"{member.ContainingType.Name}.{member.Name}";
           Context.ReportDiagnostic(Diagnostic.Create(Rule, Root.GetLocation(), access));

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -19,6 +19,7 @@
     <Description>ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
     <PackageReleaseNotes>- New Analyzer: PH_P013 - Discouraged EntityFramework Method
 - Renamed Analyzer: PH_P003 - Discouraged Thread Method (was Discouraged Method)
+- Renamed Analyzer: PH_P005 - Blocking Wait on Async Method (was Missing Gate-Keeper)
 - Improved Analyzer: PH_B014 - Now reports await of as-expressions</PackageReleaseNotes>
     <Copyright>Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>


### PR DESCRIPTION
This PR renames PH_P005 to Blocking Wait on Async Method. Furthermore, it improves the documentation to only use the gate-keeper if there is no alternative to blockingly call the asynchronous method.