### PR TITLE
PH_P007: Allow method exclusions

### DIFF
--- a/doc/analyzers/PH_P004.md
+++ b/doc/analyzers/PH_P004.md
@@ -7,3 +7,11 @@ The current method receives a cancellation token that is not passed to the invok
 ## Solution
 
 Pass the received cancellation token to the invoked method. If the invoked method must not be canceled (e.g., for logging a failure), pass `CancellationToken.None` instead to explicitly state the intention.
+
+## Options
+
+```ini
+# A white-space separated list of methods to exclude when searching for method invocations that miss the cancellation token
+# Format: <type-specifier>:<method1>,<method2>
+dotnet_diagnostic.PH_P007.exclusions = System.Threading.Tasks.Task:Run
+```

--- a/reportall.editorconfig
+++ b/reportall.editorconfig
@@ -8,6 +8,7 @@ dotnet_diagnostic.PH_P004.severity = warning
 dotnet_diagnostic.PH_P005.severity = warning
 dotnet_diagnostic.PH_P006.severity = warning
 dotnet_diagnostic.PH_P007.severity = warning
+dotnet_diagnostic.PH_P007.exclusions = 
 dotnet_diagnostic.PH_P008.severity = warning
 dotnet_diagnostic.PH_P009.severity = warning
 dotnet_diagnostic.PH_P010.severity = warning

--- a/src/ParallelHelper.Plugin/ReleaseNotes.txt
+++ b/src/ParallelHelper.Plugin/ReleaseNotes.txt
@@ -6,6 +6,7 @@
 - Improved Analyzer: PH_B014 - Now reports await of as-expressions
 - Improved Analyzer: PH_P005 - Now reports blocking accesses on ValueTasks
 - Improved Analyzer: PH_S026 - Now reports blocking accesses on ValueTasks
+- Improved Analyzer: PH_P007 - Now supports method exclusions (Task.Run by default)
 
 
 ------------------

--- a/src/ParallelHelper.Test/Analyzer/BestPractices/UnusedCancellationTokenFromEnclosingScopeAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/BestPractices/UnusedCancellationTokenFromEnclosingScopeAnalyzerTest.cs
@@ -143,6 +143,23 @@ class Test {
     }
 
     [TestMethod]
+    public void ReportsIfMissingForMethodThatIsExcludedByDefaultButReenabled() {
+      const string source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync1(CancellationToken cancellationToken = default) {
+    await Task.Run(() => {});
+  }
+}";
+      CreateAnalyzerCompilationBuilder()
+        .AddSourceTexts(source)
+        .AddAnalyzerOption("dotnet_diagnostic.PH_P007.exclusions", "")
+        .VerifyDiagnostic(new DiagnosticResultLocation(6, 11));
+    }
+
+    [TestMethod]
     public void DoesNotReportIfCancellationTokenIsPassed() {
       const string source = @"
 using System.Threading;
@@ -384,7 +401,6 @@ class Test {
 }";
       VerifyDiagnostic(source);
     }
-
 
     [TestMethod]
     public void DoesNotReportIfMissingForMethodThatIsManuallyExcluded() {

--- a/src/ParallelHelper.Test/Analyzer/BestPractices/UnusedCancellationTokenFromEnclosingScopeAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/BestPractices/UnusedCancellationTokenFromEnclosingScopeAnalyzerTest.cs
@@ -369,5 +369,38 @@ class Test : Base {
 }";
       VerifyDiagnostic(source, new DiagnosticResultLocation(11, 11));
     }
+
+
+    [TestMethod]
+    public void DoesNotReportIfMissingForMethodThatIsExcludedByDefault() {
+      const string source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync1(CancellationToken cancellationToken = default) {
+    await Task.Run(() => {});
+  }
+}";
+      VerifyDiagnostic(source);
+    }
+
+
+    [TestMethod]
+    public void DoesNotReportIfMissingForMethodThatIsManuallyExcluded() {
+      const string source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class Test {
+  public async Task DoWorkAsync1(CancellationToken cancellationToken = default) {
+    await Task.Delay(1000);
+  }
+}";
+      CreateAnalyzerCompilationBuilder()
+        .AddSourceTexts(source)
+        .AddAnalyzerOption("dotnet_diagnostic.PH_P007.exclusions", "System.Threading.Tasks.Task:Delay")
+        .VerifyDiagnostic();
+    }
   }
 }

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -22,7 +22,8 @@
 - Renamed Analyzer: PH_P005 - Blocking Wait on Async Method (was Missing Gate-Keeper)
 - Improved Analyzer: PH_B014 - Now reports await of as-expressions
 - Improved Analyzer: PH_P005 - Now reports blocking accesses on ValueTasks
-- Improved Analyzer: PH_S026 - Now reports blocking accesses on ValueTasks</PackageReleaseNotes>
+- Improved Analyzer: PH_S026 - Now reports blocking accesses on ValueTasks
+- Improved Analyzer: PH_P007 - Now supports method exclusions (Task.Run by default)</PackageReleaseNotes>
     <Copyright>Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
This PR enables method exclusions using the option `dotnet_diagnostic.PH_P007.exclusions`. By default, thew `Task.Run` method is excluded.