### PR TITLE
PH_S032: Allow excluding exception types

### DIFF
--- a/doc/analyzers/PH_S032.md
+++ b/doc/analyzers/PH_S032.md
@@ -8,3 +8,11 @@ If such a *potentially async method* throws an exception inside its body, it beh
 ## Solution
 
 Encapsulate the exceptions in a task using `Task.FromException(...)`.
+
+## Options
+
+```ini
+# A white-space separated list of exception types to not report
+# Format: <type-specifier1> <type-specifier2> ...
+dotnet_diagnostic.PH_S032.exclusions = System.ArgumentException System.NotImplementedException
+```

--- a/reportall.editorconfig
+++ b/reportall.editorconfig
@@ -50,6 +50,7 @@ dotnet_diagnostic.PH_S029.severity = warning
 dotnet_diagnostic.PH_S030.severity = warning
 dotnet_diagnostic.PH_S031.severity = warning
 dotnet_diagnostic.PH_S032.severity = warning
+dotnet_diagnostic.PH_S032.exclusions = 
 dotnet_diagnostic.PH_S033.severity = warning
 
 # Bugs

--- a/src/ParallelHelper.Plugin/ReleaseNotes.txt
+++ b/src/ParallelHelper.Plugin/ReleaseNotes.txt
@@ -3,6 +3,7 @@
 - Improved Analyzer: PH_S019 - Now matches parameter types (only the first by default)
 - Improved Analyzer: PH_B004 - Now only respects the while-loop's condition
 - Improved Analyzer: PH_B009 - Now ignores readonly fields by default
+- Improved Analyzer: PH_S032 - Now supports exception type exclusions (ArgumentException and NotImplementedException by default)
 
 
 ------------------

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -19,7 +19,8 @@
     <Description>ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
     <PackageReleaseNotes>- Improved Analyzer: PH_S019 - Now matches parameter types (only the first by default)
 - Improved Analyzer: PH_B004 - Now only respects the while-loop's condition
-- Improved Analyzer: PH_B009 - Now ignores readonly fields by default</PackageReleaseNotes>
+- Improved Analyzer: PH_B009 - Now ignores readonly fields by default
+- Improved Analyzer: PH_S032 - Now supports exception type exclusions (ArgumentException and NotImplementedException by default)</PackageReleaseNotes>
     <Copyright>Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
This PR adds the option to PH_S032 to exclude certain exception types. By default, `System.ArgumentException` and `System.InvalidOperationException` are now excluded.

The exclusions can be configured using the following option:
```ini
# A white-space separated list of exception types to not report
# Format: <type-specifier1> <type-specifier2> ...
dotnet_diagnostic.PH_S032.exclusions = System.ArgumentException System.NotImplementedException
```
