### PR TITLE
PH_P007: Exclude private base type members

### DIFF
--- a/src/ParallelHelper.Plugin/ReleaseNotes.txt
+++ b/src/ParallelHelper.Plugin/ReleaseNotes.txt
@@ -4,6 +4,7 @@
 - Improved Analyzer: PH_B004 - Now only respects the while-loop's condition
 - Improved Analyzer: PH_B009 - Now ignores readonly fields by default
 - Improved Analyzer: PH_S032 - Now supports exception type exclusions (ArgumentException and NotImplementedException by default)
+- Improved Analyzer: PH_P007 - Now excludes private members from base types
 
 
 ------------------

--- a/src/ParallelHelper.Test/Analyzer/BestPractices/UnusedCancellationTokenFromEnclosingScopeAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/BestPractices/UnusedCancellationTokenFromEnclosingScopeAnalyzerTest.cs
@@ -384,7 +384,7 @@ class Test : Base {
     return Task.CompletedTask;
   }
 }";
-      VerifyDiagnostic(source, new DiagnosticResultLocation(11, 11));
+      VerifyDiagnostic(source);
     }
 
 
@@ -417,6 +417,27 @@ class Test {
         .AddSourceTexts(source)
         .AddAnalyzerOption("dotnet_diagnostic.PH_P007.exclusions", "System.Threading.Tasks.Task:Delay")
         .VerifyDiagnostic();
+    }
+
+
+    [TestMethod]
+    public void DoesNotReportMissingForMethodCallWhereCancellationTokenIsPrivateFromBaseType() {
+      const string source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class Test : Base {
+  public async Task DoWorkAsync() {
+    await DoInternalAsync();
+  }
+
+  private async Task DoInternalAsync(CancellationToken cancellationToken = default) {}
+}
+
+class Base {
+  private readonly CancellationTokenSource cancellationToken = new CancellationTokenSource();
+}";
+      VerifyDiagnostic(source);
     }
   }
 }

--- a/src/ParallelHelper/Analyzer/BestPractices/UnusedCancellationTokenFromEnclosingScopeAnalyzer.cs
+++ b/src/ParallelHelper/Analyzer/BestPractices/UnusedCancellationTokenFromEnclosingScopeAnalyzer.cs
@@ -74,8 +74,7 @@ namespace ParallelHelper.Analyzer.BestPractices {
         Func<TSymbol, ITypeSymbol?> getType,
         Func<TSymbol, bool> isStatic
       ) where TSymbol : ISymbol {
-        return classSymbol.GetAllBaseTypesAndSelf()
-          .SelectMany(type => type.GetMembers())
+        return classSymbol.GetAllAccessibleMembers()
           .WithCancellation(context.CancellationToken)
           .OfType<TSymbol>()
           .Where(field => getType(field) != null)

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -20,7 +20,8 @@
     <PackageReleaseNotes>- Improved Analyzer: PH_S019 - Now matches parameter types (only the first by default)
 - Improved Analyzer: PH_B004 - Now only respects the while-loop's condition
 - Improved Analyzer: PH_B009 - Now ignores readonly fields by default
-- Improved Analyzer: PH_S032 - Now supports exception type exclusions (ArgumentException and NotImplementedException by default)</PackageReleaseNotes>
+- Improved Analyzer: PH_S032 - Now supports exception type exclusions (ArgumentException and NotImplementedException by default)
+- Improved Analyzer: PH_P007 - Now excludes private members from base types</PackageReleaseNotes>
     <Copyright>Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
PH_P007 falsely reported cancellation tokens from private members of a class's base types (inaccessible by the subclass). This PR resolves this issue.