### PR TITLE
PH_B008: Remove obsolete methods

### DIFF
--- a/src/ParallelHelper.Plugin/ReleaseNotes.txt
+++ b/src/ParallelHelper.Plugin/ReleaseNotes.txt
@@ -3,6 +3,7 @@
 - Improved Analyzer: PH_S019 - Now matches parameter types (only the first by default)
 - Improved Analyzer: PH_B004 - Now only respects the while-loop's condition
 - Improved Analyzer: PH_B009 - Now ignores readonly fields by default
+- Improved Analyzer: PH_B008 - No longer reports ToImmutableDictionary and ToImmutableHashSet
 
 
 ------------------

--- a/src/ParallelHelper/Analyzer/Bugs/LinqToCollectionOnConcurrentDictionaryAnalyzer.cs
+++ b/src/ParallelHelper/Analyzer/Bugs/LinqToCollectionOnConcurrentDictionaryAnalyzer.cs
@@ -46,8 +46,6 @@ namespace ParallelHelper.Analyzer.Bugs {
     private static readonly ClassMemberDescriptor[] LinqDescriptors = {
       new ClassMemberDescriptor("System.Linq.Enumerable", "ToArray", "ToList"),
       new ClassMemberDescriptor("System.Collections.Immutable.ImmutableArray", "ToImmutableArray"),
-      new ClassMemberDescriptor("System.Collections.Immutable.ImmutableDictionary", "ToImmutableDictionary"),
-      new ClassMemberDescriptor("System.Collections.Immutable.ImmutableHashSet", "ToImmutableHashSet"),
       new ClassMemberDescriptor("System.Collections.Immutable.ImmutableList", "ToImmutableList"),
     };
 

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -19,7 +19,8 @@
     <Description>ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
     <PackageReleaseNotes>- Improved Analyzer: PH_S019 - Now matches parameter types (only the first by default)
 - Improved Analyzer: PH_B004 - Now only respects the while-loop's condition
-- Improved Analyzer: PH_B009 - Now ignores readonly fields by default</PackageReleaseNotes>
+- Improved Analyzer: PH_B009 - Now ignores readonly fields by default
+- Improved Analyzer: PH_B008 - No longer reports ToImmutableDictionary and ToImmutableHashSet</PackageReleaseNotes>
     <Copyright>Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
This PR intends to remove `ToImmutableDictionary` and `ToImmutableHashSet` from the list of reported methods since they do not have the problematic optimization.