### PR TITLE
PH_S032: Exclude sub-types

### DIFF
--- a/doc/analyzers/PH_S032.md
+++ b/doc/analyzers/PH_S032.md
@@ -12,7 +12,7 @@ Encapsulate the exceptions in a task using `Task.FromException(...)`.
 ## Options
 
 ```ini
-# A white-space separated list of exception types to not report
+# A white-space separated list of exception types to not report. The sub-types of these types will be excluded too.
 # Format: <type-specifier1> <type-specifier2> ...
 dotnet_diagnostic.PH_S032.exclusions = System.ArgumentException System.NotImplementedException
 ```

--- a/src/ParallelHelper.Test/Analyzer/Smells/ThrowsInPotentiallyAsyncMethodAnalyzerTest.cs
+++ b/src/ParallelHelper.Test/Analyzer/Smells/ThrowsInPotentiallyAsyncMethodAnalyzerTest.cs
@@ -110,5 +110,25 @@ class Test {
         .AddAnalyzerOption("dotnet_diagnostic.PH_S032.exclusions", "System.InvalidOperationException")
         .VerifyDiagnostic();
     }
+
+    [TestMethod]
+    public void DoesNotReportNonAsyncMethodWithAsyncSuffixAndReturningTaskThatUsesThrowsExpressionWithSubTypeOfExcludedType() {
+      const string source = @"
+using System;
+using System.Threading.Tasks;
+
+class Test {
+  private string value;
+
+  public Task<int> DoWorkAsync(string value) {
+    this.value = value ?? throw new ArgumentNullException(nameof(value));
+    return Task.FromResult(value.Length);
+  }
+}";
+      CreateAnalyzerCompilationBuilder()
+        .AddSourceTexts(source)
+        .AddAnalyzerOption("dotnet_diagnostic.PH_S032.exclusions", "System.ArgumentException")
+        .VerifyDiagnostic();
+    }
   }
 }

--- a/src/ParallelHelper/Extensions/TypeSymbolExtensions.cs
+++ b/src/ParallelHelper/Extensions/TypeSymbolExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace ParallelHelper.Extensions {
   /// <summary>
@@ -76,6 +77,20 @@ namespace ParallelHelper.Extensions {
     /// <returns>All the members of the type and its base types.</returns>
     public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol type) {
       return GetAllBaseTypesAndSelf(type).SelectMany(baseType => baseType.GetMembers());
+    }
+
+    /// <summary>
+    /// Checks if the given type is a base type of the given type.
+    /// </summary>
+    /// <param name="baseType">The base type to check.</param>
+    /// <param name="subType">The type to check if it's a sub type of the given base type.</param>
+    /// <param name="cancellationToken">A token to stop the check before completion.</param>
+    /// <returns><c>True</c> if the given type is a sub-type of the given base type.</returns>
+    /// <remarks>This check does not include interfaces.</remarks>
+    public static bool IsBaseTypeOf(this ITypeSymbol baseType, ITypeSymbol subType, CancellationToken cancellationToken) {
+      return subType.GetAllBaseTypesAndSelf()
+        .WithCancellation(cancellationToken)
+        .Any(type => baseType.Equals(type, SymbolEqualityComparer.Default));
     }
   }
 }


### PR DESCRIPTION
This PR resolves #89 by also excluding the sub-types of the exclusions. For example, if `ArgumentException` is excluded, the analysis will no longer report the sub-type `ArgumentNullException`.