### PR TITLE
PH_B016: Support nested activation frames

### DIFF
--- a/src/ParallelHelper/Analyzer/Bugs/ExceptionHandlingOnUnawaitedTask.cs
+++ b/src/ParallelHelper/Analyzer/Bugs/ExceptionHandlingOnUnawaitedTask.cs
@@ -86,6 +86,7 @@ namespace ParallelHelper.Analyzer.Bugs {
         foreach(var catchClause in node.Catches) {
           catchClause.Accept(this);
         }
+        node.Finally?.Accept(this);
       }
 
       public override void VisitReturnStatement(ReturnStatementSyntax node) {


### PR DESCRIPTION
The current implementation of PH_B016 stops visiting if a new activation frame is encountered. Therefore, if the pattern occurs within a nested activation frame, it won't be reported. This PR makes the implementation more flexible to support these cases.