### PR TITLE
PH_S020: Refactor to TaskAnalysis

### DIFF
--- a/src/ParallelHelper.Test/Util/TaskAnalysisTest.cs
+++ b/src/ParallelHelper.Test/Util/TaskAnalysisTest.cs
@@ -861,5 +861,65 @@ public class Test {
       var analysis = new TaskAnalysis(semanticModel, default);
       Assert.IsFalse(analysis.IsFromResultInvocation(invocation));
     }
+
+
+
+    [TestMethod]
+    public void IsCompletedTaskAccessReturnsTrueForAccessingCompletedTask() {
+      const string source = @"
+using System.Threading.Tasks;
+
+public class Test {
+  public void DoIt() {
+    var task = Task.CompletedTask;
+  }
+}";
+      var semanticModel = CompilationFactory.GetSemanticModel(source);
+      var memberAccess = semanticModel.SyntaxTree.GetRoot()
+        .DescendantNodes()
+        .OfType<MemberAccessExpressionSyntax>()
+        .Single();
+      var analysis = new TaskAnalysis(semanticModel, default);
+      Assert.IsTrue(analysis.IsCompletedTaskAccess(memberAccess));
+    }
+
+    [TestMethod]
+    public void IsCompletedTaskAccessReturnsFalseForAccessingUnknownTaskMember() {
+      const string source = @"
+using System.Threading.Tasks;
+
+public class Test {
+  public void DoIt() {
+    var task = Task.SomeNotExistantProperty;
+  }
+}";
+      var semanticModel = CompilationFactory.GetSemanticModel(source);
+      var memberAccess = semanticModel.SyntaxTree.GetRoot()
+        .DescendantNodes()
+        .OfType<MemberAccessExpressionSyntax>()
+        .Single();
+      var analysis = new TaskAnalysis(semanticModel, default);
+      Assert.IsFalse(analysis.IsCompletedTaskAccess(memberAccess));
+    }
+
+    [TestMethod]
+    public void IsCompletedTaskAccessReturnsFalseForAccessingDifferentMember() {
+      const string source = @"
+using System;
+using System.Threading.Tasks;
+
+public class Test {
+  public void DoIt() {
+    var task = Task.Factory;
+  }
+}";
+      var semanticModel = CompilationFactory.GetSemanticModel(source);
+      var memberAccess = semanticModel.SyntaxTree.GetRoot()
+        .DescendantNodes()
+        .OfType<MemberAccessExpressionSyntax>()
+        .Single();
+      var analysis = new TaskAnalysis(semanticModel, default);
+      Assert.IsFalse(analysis.IsCompletedTaskAccess(memberAccess));
+    }
   }
 }

--- a/src/ParallelHelper/Analyzer/Smells/AwaitSynchronousTaskCompletionAnalyzer.cs
+++ b/src/ParallelHelper/Analyzer/Smells/AwaitSynchronousTaskCompletionAnalyzer.cs
@@ -35,9 +35,6 @@ namespace ParallelHelper.Analyzer.Smells {
       isEnabledByDefault: true, description: Description, helpLinkUri: HelpLinkFactory.CreateUri(DiagnosticId)
     );
 
-    private const string TaskType = "System.Threading.Tasks.Task";
-    private const string CompletedTaskProperty = "CompletedTask";
-
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context) {

--- a/src/ParallelHelper/Util/TaskAnalysis.cs
+++ b/src/ParallelHelper/Util/TaskAnalysis.cs
@@ -36,6 +36,7 @@ namespace ParallelHelper.Util {
     );
 
     private const string FromResultMethod = "FromResult";
+    private const string CompletedTaskProperty = "CompletedTask";
 
     private readonly SemanticModel _semanticModel;
     private readonly CancellationToken _cancellationToken;
@@ -130,7 +131,16 @@ namespace ParallelHelper.Util {
     }
 
     /// <summary>
-    /// CHecks if the given node is a method or function (e.g. lambda) returns a task.
+    /// Checks if the given member access is accessing <see cref="System.Threading.Tasks.Task.CompletedTask"/>.
+    /// </summary>
+    /// <param name="memberAccess">The member access to check.</param>
+    /// <returns><c>true</c> if it's the member access of CompletedTask, <c>false</c> otherwise.</returns>
+    public bool IsCompletedTaskAccess(MemberAccessExpressionSyntax memberAccess) {
+      return IsTaskMemberAccess(memberAccess, CompletedTaskProperty);
+    }
+
+    /// <summary>
+    /// Checks if the given node is a method or function (e.g. lambda) returns a task.
     /// </summary>
     /// <param name="node">The node to check.</param>
     /// <returns><c>true</c> if the underlying method or function returns a task, <c>false</c> otherwise.</returns>
@@ -153,6 +163,12 @@ namespace ParallelHelper.Util {
     private bool IsTaskMethodInvocation(InvocationExpressionSyntax invocation, string taskMember) {
       return _semanticModel.GetSymbolInfo(invocation, _cancellationToken).Symbol is IMethodSymbol method
         && IsTaskMember(method, taskMember);
+    }
+
+    private bool IsTaskMemberAccess(MemberAccessExpressionSyntax invocation, string taskMember) {
+      var symbol = _semanticModel.GetSymbolInfo(invocation, _cancellationToken).Symbol;
+      return symbol != null
+        && IsTaskMember(symbol, taskMember);
     }
 
     private bool IsTaskMember(ISymbol member, string taskMember) {


### PR DESCRIPTION
PH_S020 searches member accesses to `Task.CompletedTask` and invocations of `Task.FromResult`. Since the shared code `TaskAnalysis` provides this functionality, this PR intends to remove the code duplication.