### PR TITLE
Modernize frameworks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ before_test:
   - dotnet tool install --global coverlet.console --version 1.7.0
 
 test_script:
-  - ps: coverlet src\ParallelHelper.Test\bin\Release\netcoreapp3.1\ParallelHelper.Test.dll --target "dotnet" --targetargs 'test src\ParallelHelper.Test -c Release -logger:""C:\Program Files\AppVeyor\BuildAgent\dotnetcore\Appveyor.MSBuildLogger.dll"" --no-build' --format opencover --output coverage.xml
+  - ps: coverlet src\ParallelHelper.Test\bin\Release\net6.0\ParallelHelper.Test.dll --target "dotnet" --targetargs 'test src\ParallelHelper.Test -c Release -logger:""C:\Program Files\AppVeyor\BuildAgent\dotnetcore\Appveyor.MSBuildLogger.dll"" --no-build' --format opencover --output coverage.xml
 
 after_test:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 version: '{build}'
 configuration: Release
 

--- a/src/ParallelHelper.Plugin/License.txt
+++ b/src/ParallelHelper.Plugin/License.txt
@@ -1,6 +1,5 @@
 Parallel Helper, Static C# Code Analyzer for Concurrency Related Issues
 Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland
-Copyright (C) 2022  Christoph Amrein
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/ParallelHelper.Plugin/License.txt
+++ b/src/ParallelHelper.Plugin/License.txt
@@ -1,5 +1,6 @@
 Parallel Helper, Static C# Code Analyzer for Concurrency Related Issues
 Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland
+Copyright (C) 2022  Christoph Amrein
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/ParallelHelper.Test/DiagnosticResultLocation.cs
+++ b/src/ParallelHelper.Test/DiagnosticResultLocation.cs
@@ -35,14 +35,14 @@ namespace ParallelHelper.Test {
       return $"{Path}: {Line},{Column}";
     }
 
-    public static bool operator==(DiagnosticResultLocation left, DiagnosticResultLocation right) {
+    public static bool operator==(DiagnosticResultLocation? left, DiagnosticResultLocation? right) {
       if(left == null) {
         return right == null;
       }
       return left.Equals(right);
     }
 
-    public static bool operator!=(DiagnosticResultLocation left, DiagnosticResultLocation right) {
+    public static bool operator!=(DiagnosticResultLocation? left, DiagnosticResultLocation? right) {
       return !(left == right);
     }
   }

--- a/src/ParallelHelper.Test/ParallelHelper.Test.csproj
+++ b/src/ParallelHelper.Test/ParallelHelper.Test.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <NullableContextOptions>enable</NullableContextOptions> <!-- pre vs 2019.2 -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ParallelHelper.Test/ParallelHelper.Test.csproj
+++ b/src/ParallelHelper.Test/ParallelHelper.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <NullableContextOptions>enable</NullableContextOptions> <!-- pre vs 2019.2 -->

--- a/src/ParallelHelper.Test/TestAnalyzerConfigOptionsProvider.cs
+++ b/src/ParallelHelper.Test/TestAnalyzerConfigOptionsProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ParallelHelper.Test {
   /// <summary>
@@ -29,7 +30,7 @@ namespace ParallelHelper.Test {
         _options = options.WithComparers(KeyComparer);
       }
 
-      public override bool TryGetValue(string key, out string value) {
+      public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value) {
         return _options.TryGetValue(key, out value);
       }
     }

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -6,7 +6,6 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <NullableContextOptions>enable</NullableContextOptions> <!-- pre vs 2019.2 -->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <Description>ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
     <PackageReleaseNotes>- New Analyzer: PH_S034 - Async Lambda Inferred to Async Void</PackageReleaseNotes>
-    <Copyright>Copyright (C) 2022  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
+    <Copyright>Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <Description>ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
     <PackageReleaseNotes>- New Analyzer: PH_S034 - Async Lambda Inferred to Async Void</PackageReleaseNotes>
-    <Copyright>Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
+    <Copyright>Copyright (C) 2022  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>


### PR DESCRIPTION
- Upgrade test project to .NET 6 (.NET Core 3.1 is EOL by the end of 2022)
- Remove settings used to support old Visual Studio versions