### PR TITLE
Update the copyright notices

### DIFF
--- a/src/ParallelHelper.Plugin/License.txt
+++ b/src/ParallelHelper.Plugin/License.txt
@@ -1,5 +1,6 @@
 Parallel Helper, Static C# Code Analyzer for Concurrency Related Issues
 Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland
+Copyright (C) 2022  Christoph Amrein
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -18,7 +18,7 @@
     <RepositoryType>git</RepositoryType>
     <Description>ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
     <PackageReleaseNotes>- New Analyzer: PH_S034 - Async Lambda Inferred to Async Void</PackageReleaseNotes>
-    <Copyright>Copyright (C) 2019 - 2021  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
+    <Copyright>Copyright (C) 2022  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -18,12 +18,12 @@
     <RepositoryType>git</RepositoryType>
     <Description>ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
     <PackageReleaseNotes>- New Analyzer: PH_S034 - Async Lambda Inferred to Async Void</PackageReleaseNotes>
-    <Copyright>Copyright (C) 2022  Christoph Amrein, Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Copyright>
+    <Copyright>Copyright (C) 2022  Christoph Amrein</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Company>Concurrency Lab, Eastern Switzerland University of Applied Sciences, Switzerland</Company>
+    <Company></Company>
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 


### PR DESCRIPTION
- Update the copyright notices to 2022
- Remove the university affiliation