### PR TITLE
Change back to v3.6.0 as this was unreleased

### DIFF
--- a/src/ParallelHelper.Plugin/ReleaseNotes.txt
+++ b/src/ParallelHelper.Plugin/ReleaseNotes.txt
@@ -1,13 +1,7 @@
-﻿v3.7.0
-
-- New Analyzer: PH_S035 - Blocking Async Method Invocation in Constructor
-
-
-------------------
-
-v3.6.0
+﻿v3.6.0
 
 - New Analyzer: PH_S034 - Async Lambda Inferred to Async Void
+- New Analyzer: PH_S035 - Blocking Async Method Invocation in Constructor
 
 
 ------------------

--- a/src/ParallelHelper.Plugin/source.extension.vsixmanifest
+++ b/src/ParallelHelper.Plugin/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ParallelHelper.f833642b-cd24-49ac-addc-e5328ce8fe88" Version="3.7.0" Language="en-US" Publisher="Christoph Amrein" />
+        <Identity Id="ParallelHelper.f833642b-cd24-49ac-addc-e5328ce8fe88" Version="3.6.0" Language="en-US" Publisher="Christoph Amrein" />
         <DisplayName>ParallelHelper</DisplayName>
         <Description xml:space="preserve">ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
         <MoreInfo>https://github.com/Concurrency-Lab/ParallelHelper</MoreInfo>

--- a/src/ParallelHelper/ParallelHelper.csproj
+++ b/src/ParallelHelper/ParallelHelper.csproj
@@ -10,13 +10,14 @@
 
   <PropertyGroup>
     <PackageId>ParallelHelper</PackageId>
-    <Version>3.7.0</Version>
+    <Version>3.6.0</Version>
     <Authors>Christoph Amrein</Authors>
     <PackageProjectUrl>https://github.com/Concurrency-Lab/ParallelHelper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Concurrency-Lab/ParallelHelper</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <Description>ParallelHelper is a static code analyzer that helps to identify concurrency related issues. Moreover, it provides hints to improve the robustness of code with concurrency in mind.</Description>
-    <PackageReleaseNotes>- New Analyzer: PH_S035 - Blocking Async Method Invocation in Constructor</PackageReleaseNotes>
+    <PackageReleaseNotes>- New Analyzer: PH_S034 - Async Lambda Inferred to Async Void
+- New Analyzer: PH_S035 - Blocking Async Method Invocation in Constructor</PackageReleaseNotes>
     <Copyright>Copyright (C) 2022  Christoph Amrein</Copyright>
     <PackageTags>C#, Parallel, Asynchronous, Concurrency, Bugs, Best Practices, TPL, Task, QC, Static Analysis, async, await</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
`v3.6.0` wasn't released yet; thus, we switch down from `v3.7.0` to not skip a version