### PR TITLE
Move PH_P007 options to the right doc

### DIFF
--- a/doc/analyzers/PH_P004.md
+++ b/doc/analyzers/PH_P004.md
@@ -7,11 +7,3 @@ The current method receives a cancellation token that is not passed to the invok
 ## Solution
 
 Pass the received cancellation token to the invoked method. If the invoked method must not be canceled (e.g., for logging a failure), pass `CancellationToken.None` instead to explicitly state the intention.
-
-## Options
-
-```ini
-# A white-space separated list of methods to exclude when searching for method invocations that miss the cancellation token
-# Format: <type-specifier>:<method1>,<method2>
-dotnet_diagnostic.PH_P007.exclusions = System.Threading.Tasks.Task:Run
-```

--- a/doc/analyzers/PH_P007.md
+++ b/doc/analyzers/PH_P007.md
@@ -7,3 +7,11 @@ One of the enclosing scopes holds a cancellation token. However, an invoked meth
 ## Solution
 
 Pass the cancellation token of the enclosing scope to the invoked method. If the invoked method must not be canceled (e.g., for logging a failure), pass `CancellationToken.None` instead to explicitly state the intention.
+
+## Options
+
+```ini
+# A white-space separated list of methods to exclude when searching for method invocations that miss the cancellation token
+# Format: <type-specifier>:<method1>,<method2>
+dotnet_diagnostic.PH_P007.exclusions = System.Threading.Tasks.Task:Run
+```


### PR DESCRIPTION
While reviewing the bug report #104, it was found that the docs for excluding methods in PH_P007 was wrongly placed in PH_P004. This PR intends to move the options descriptions to the right place.